### PR TITLE
Fixes the "undefined method `gsub' for nil:NilClass" error for form_for @instance

### DIFF
--- a/lib/s3_file_field/form_helper.rb
+++ b/lib/s3_file_field/form_helper.rb
@@ -16,7 +16,7 @@ module S3FileField
     def s3_file_field(object_name, method, options = {})
       uploader = S3Uploader.new(options)
       options = options.reverse_merge(uploader.field_options)
-      options.delete(:object) if options[:object].new_record?
+      options.delete(:object) if (options[:object] && options[:object].new_record?)
       if ::Rails.version.to_i >= 4
         ActionView::Helpers::Tags::FileField.new(
           object_name, method, self, options


### PR DESCRIPTION
In S3FileField::FormHelper, delete the object from options hash if the object is a new record, as it will otherwise raise an "undefined method `gsub' for nil:NilClass" error for new records if the form is passed an instance rather than a symbol.
