### PR TITLE
Add hostname and port config options

### DIFF
--- a/lib/s3_file_field/config_aws.rb
+++ b/lib/s3_file_field/config_aws.rb
@@ -12,7 +12,9 @@ module S3FileField
       :region,
       :key_starts_with,
       :ssl,
-      :url
+      :url,
+      :aws_hostname,
+      :aws_port
     ]
 
     attr_accessor *ATTRIBUTES

--- a/lib/s3_file_field/s3_uploader.rb
+++ b/lib/s3_file_field/s3_uploader.rb
@@ -15,7 +15,9 @@ module S3FileField
         key_starts_with: S3FileField.config.key_starts_with || 'uploads/',
         region: S3FileField.config.region || 's3',
         url: S3FileField.config.url,
-        ssl: S3FileField.config.ssl
+        ssl: S3FileField.config.ssl,
+        aws_hostname: S3FileField.config.aws_hostname,
+        aws_port: S3FileField.config.aws_port
       }
 
       @key = original_options[:key]
@@ -67,8 +69,16 @@ module S3FileField
           @options[:url]
         else
           protocol = @options[:ssl] == true ? "https" : @options[:ssl] == false ? "http" : nil
-          subdomain = "#{@options[:bucket]}.#{@options[:region]}"
-          domain = "//#{subdomain}.amazonaws.com/"
+          if @options[:aws_hostname]
+            if @options[:aws_port]
+              domain = "//#{@options[:aws_hostname]}:#{@options[:aws_port]}/"
+            else
+              domain = "//#{@options[:aws_hostname]}/"
+            end
+          else
+            subdomain = "#{@options[:bucket]}.#{@options[:region]}"
+            domain = "//#{subdomain}.amazonaws.com/"
+          end
           [protocol, domain].compact.join(":")
         end
     end

--- a/spec/s3_file_field/s3_uploader_spec.rb
+++ b/spec/s3_file_field/s3_uploader_spec.rb
@@ -103,6 +103,22 @@ module S3FileField
         s3_uploader = S3Uploader.new(:bucket => "geocities-backup", :region => "s3-us-middle-3")
         expect(s3_uploader.field_data_options[:url]).to eq "//geocities-backup.s3-us-middle-3.amazonaws.com/"
       end
+
+      it "can be overridden with a different hostname" do
+        S3FileField.config.aws_hostname = "foo.bar"
+        s3_uploader = S3Uploader.new
+        expect(s3_uploader.field_data_options[:url]).to eq "//foo.bar/"
+        S3FileField.config.aws_hostname = nil
+      end
+
+      it "can be overridden with a different hostname and port" do
+        S3FileField.config.aws_hostname = "foo.bar"
+        S3FileField.config.aws_port = 1234
+        s3_uploader = S3Uploader.new(:aws_hostname => "foo.bar", :aws_port => 1234)
+        expect(s3_uploader.field_data_options[:url]).to eq "//foo.bar:1234/"
+        S3FileField.config.aws_hostname = nil
+        S3FileField.config.aws_port = nil
+      end
     end
 
     context '#field_options' do


### PR DESCRIPTION
This PR adds hostname and port options, which allow something like FakeS3 to be used locally.
